### PR TITLE
로그인, 로그아웃 기능 구현

### DIFF
--- a/user-service/src/main/kotlin/com/fastcampus/userservice/config/WebConfig.kt
+++ b/user-service/src/main/kotlin/com/fastcampus/userservice/config/WebConfig.kt
@@ -1,16 +1,47 @@
 package com.fastcampus.userservice.config
 
+import com.fastcampus.userservice.model.AuthToken
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.MethodParameter
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.BindingContext
 import org.springframework.web.reactive.config.CorsRegistry
 import org.springframework.web.reactive.config.WebFluxConfigurer
+import org.springframework.web.reactive.result.method.HandlerMethodArgumentResolver
+import org.springframework.web.reactive.result.method.annotation.ArgumentResolverConfigurer
+import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Mono
+import reactor.kotlin.core.publisher.toMono
 
 @Configuration
-class WebConfig : WebFluxConfigurer {
+class WebConfig(
+    private val authTokenResolver: AuthTokenResolver,
+) : WebFluxConfigurer {
+
+    override fun configureArgumentResolvers(configurer: ArgumentResolverConfigurer) {
+        super.configureArgumentResolvers(configurer)
+        configurer.addCustomResolver(authTokenResolver)
+    }
 
     override fun addCorsMappings(registry: CorsRegistry) {
         registry.addMapping("/**")
             .allowedOrigins("*")
             .allowedMethods("GET", "POST", "PUT", "DELETE")
             .maxAge(3600)
+    }
+}
+
+@Component
+class AuthTokenResolver : HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return parameter.hasParameterAnnotation(AuthToken::class.java)
+    }
+
+    override fun resolveArgument(parameter: MethodParameter, bindingContext: BindingContext, exchange: ServerWebExchange): Mono<Any> {
+        val authHeader = exchange.request.headers["Authorization"]?.first()
+        checkNotNull(authHeader)
+
+        val token = authHeader.split(" ")[1]
+        return token.toMono()
     }
 }

--- a/user-service/src/main/kotlin/com/fastcampus/userservice/controller/UserController.kt
+++ b/user-service/src/main/kotlin/com/fastcampus/userservice/controller/UserController.kt
@@ -1,11 +1,12 @@
 package com.fastcampus.userservice.controller
 
+import com.fastcampus.userservice.model.AuthToken
+import com.fastcampus.userservice.model.SignInRequest
+import com.fastcampus.userservice.model.SignInResponse
 import com.fastcampus.userservice.model.SignUpRequest
 import com.fastcampus.userservice.service.UserService
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -16,5 +17,16 @@ class UserController(
     @PostMapping("/signup")
     suspend fun signUp(@RequestBody request: SignUpRequest) {
         userService.signUp(request)
+    }
+
+    @PostMapping("/signin")
+    suspend fun signIn(@RequestBody request: SignInRequest): SignInResponse {
+        return userService.signIn(request)
+    }
+
+    @DeleteMapping("/logout")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    suspend fun logout(@AuthToken token: String) {
+        userService.logout(token)
     }
 }

--- a/user-service/src/main/kotlin/com/fastcampus/userservice/exception/ServerException.kt
+++ b/user-service/src/main/kotlin/com/fastcampus/userservice/exception/ServerException.kt
@@ -8,3 +8,12 @@ sealed class ServerException(
 data class UserExistsException(
     override val message: String = "이미 존재하는 유저입니다",
 ) : ServerException(409, message)
+
+
+data class UserNotFoundException(
+    override val message: String = "유저가 존재하지 않습니다",
+) : ServerException(404, message)
+
+data class PasswordNotMatchedException(
+    override val message: String = "패스워드가 잘못되었습니다",
+) : ServerException(404, message)

--- a/user-service/src/main/kotlin/com/fastcampus/userservice/model/AuthToken.kt
+++ b/user-service/src/main/kotlin/com/fastcampus/userservice/model/AuthToken.kt
@@ -1,0 +1,6 @@
+package com.fastcampus.userservice.model
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+annotation class AuthToken()

--- a/user-service/src/main/kotlin/com/fastcampus/userservice/model/SignModel.kt
+++ b/user-service/src/main/kotlin/com/fastcampus/userservice/model/SignModel.kt
@@ -5,3 +5,14 @@ data class SignUpRequest(
     val password: String,
     val username: String
 )
+
+data class SignInRequest(
+    val email: String,
+    val password: String
+)
+
+data class SignInResponse(
+    val email: String,
+    val username: String,
+    val token: String
+)

--- a/user-service/src/main/kotlin/com/fastcampus/userservice/service/CoroutineCacheManager.kt
+++ b/user-service/src/main/kotlin/com/fastcampus/userservice/service/CoroutineCacheManager.kt
@@ -1,0 +1,22 @@
+package com.fastcampus.userservice.service
+
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+
+@Component
+class CoroutineCacheManager<T> {
+
+    private val localCache = ConcurrentHashMap<String, CacheWrapper<T>>()
+
+    suspend fun awaitPut(key: String, value: T, ttl: Duration) {
+        localCache[key] = CacheWrapper(cached = value, Instant.now().plusMillis(ttl.toMillis()))
+    }
+
+    suspend fun awaitEvict(key: String) {
+        localCache.remove(key)
+    }
+
+    data class CacheWrapper<T>(val cached: T, val ttl: Instant)
+}

--- a/user-service/src/main/kotlin/com/fastcampus/userservice/service/UserService.kt
+++ b/user-service/src/main/kotlin/com/fastcampus/userservice/service/UserService.kt
@@ -1,19 +1,33 @@
 package com.fastcampus.userservice.service
 
+import com.fastcampus.userservice.config.JWTProperties
 import com.fastcampus.userservice.domain.entity.User
 import com.fastcampus.userservice.domain.repository.UserRepository
+import com.fastcampus.userservice.exception.PasswordNotMatchedException
 import com.fastcampus.userservice.exception.UserExistsException
+import com.fastcampus.userservice.exception.UserNotFoundException
+import com.fastcampus.userservice.model.SignInRequest
+import com.fastcampus.userservice.model.SignInResponse
 import com.fastcampus.userservice.model.SignUpRequest
 import com.fastcampus.userservice.utils.BCryptUtils
+import com.fastcampus.userservice.utils.JWTClaim
+import com.fastcampus.userservice.utils.JWTUtils
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
+import java.time.Duration
 
 @Service
 class UserService(
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val jwtProperties: JWTProperties,
+    private val cacheManager: CoroutineCacheManager<User>,
 ) {
 
     val log = KotlinLogging.logger {}
+
+    companion object {
+        private val CACHE_TTL = Duration.ofMinutes(1)
+    }
 
     suspend fun signUp(signUpRequest: SignUpRequest) {
         with(signUpRequest) {
@@ -27,5 +41,34 @@ class UserService(
             )
             userRepository.save(user)
         }
+    }
+
+    suspend fun signIn(request: SignInRequest): SignInResponse {
+        return with(userRepository.findByEmail(request.email) ?: throw UserNotFoundException()) {
+            val verified = BCryptUtils.verify(request.password, password)
+            if (!verified) {
+                throw PasswordNotMatchedException()
+            }
+
+            val jwtClaim = JWTClaim(
+                userId = id!!,
+                email = email,
+                profileUrl = profileUrl,
+                username = username,
+            )
+
+            val token = JWTUtils.createToken(jwtClaim, jwtProperties)
+            cacheManager.awaitPut(key = token, value = this, ttl = CACHE_TTL)
+
+            SignInResponse(
+                email = email,
+                username = username,
+                token = token,
+            )
+        }
+    }
+
+    suspend fun logout(token: String) {
+        cacheManager.awaitEvict(token)
     }
 }

--- a/user-service/src/main/kotlin/com/fastcampus/userservice/utils/JWTUtils.kt
+++ b/user-service/src/main/kotlin/com/fastcampus/userservice/utils/JWTUtils.kt
@@ -34,6 +34,6 @@ object JWTUtils {
 data class JWTClaim(
     val userId: Long,
     val email: String,
-    val profileUrl: String,
+    val profileUrl: String? = null,
     val username: String,
 )


### PR DESCRIPTION
1. profileUrl ddl과 마찬가지로 null 허용하게끔 수정
2. 어노테이션 생성 및 handlerresolver에 등록해주기
3. 로그아웃을 위해서 token을 발급함과 동시에 메모리 hashmap에서 지니고 있다가 삭제할 수 있도록 manager 생성
4. 로그인할 시 사용할 Exception 정의
5. 로그인, 로그아웃 기능 구현

close #30 